### PR TITLE
Thobiaslarsen/refactoring

### DIFF
--- a/Mango/Mango/AbSyn.fs
+++ b/Mango/Mango/AbSyn.fs
@@ -13,7 +13,16 @@ let fromCString (s : string) : string =
 
 type Position = int * int // (line, column)
 
-type CommonProp = | IsVisible of bool * Position
+type Thickness =
+    | Uniform of int
+    | Symmetric of int * int
+    | Custom of int * int * int * int
+
+type CommonProp = 
+    | IsVisible of bool * Position
+    | Margin of Thickness * Position
+    | Width of int * Position
+    | Height of int * Position
 
 type Value =
     | Int of int
@@ -32,14 +41,6 @@ type Stmt =
 
 type FunctionT = 
     | Function of string * Stmt list * Position
-
-type ButtonProp =
-    | Width of int * Position
-    | Height of int * Position
-
-type ButtonProperty = 
-    | CommonProp of CommonProp
-    | ButtonProp of ButtonProp
 
 type FontStyleT = 
     | Italic
@@ -76,11 +77,6 @@ type TextTrimT =
     | Character
     | NoTrim
 
-type Thickness =
-    | Uniform of int
-    | Symmetric of int * int
-    | Custom of int * int * int * int
-
 type LayoutT =
     | Horizontal
     | Vertical
@@ -93,8 +89,6 @@ type TextBlockProp =
     | FontSize of int * Position
     | FontWeight of int * Position
     | FontStyle of FontStyleT list * Position
-    // Margin
-    | Margin of Thickness * Position
     // Formatting
     | LineHeight of int * Position
     | TextWrap of TextWrapT * Position
@@ -103,18 +97,21 @@ type TextBlockProp =
 
 type ContainerProp =
     | Layout of LayoutT * Position
-    | Margin of Thickness * Position
+
+type InterleavedProp<'specific> =
+  | Common of CommonProp
+  | Specific of 'specific
 
 type UIElement = 
-    | Button of string * ButtonProperty list * Position
-    | TextBlock of string * TextBlockProp list option * Position
+    | Button of string * CommonProp list option * Position
+    | TextBlock of string * CommonProp list option * TextBlockProp list option * Position
     | TextBox of string * Position 
     | CheckBox of string * Position
     | RadioButton of string * Position
     | ToggleSwitch of string * Position
     | Calendar of Position
     | ToggleButton of Position
-    | Container of ContainerProp list * UIElement list * Position
+    | Container of CommonProp list option * ContainerProp list option * UIElement list * Position
 
 type Window = 
     | Window of string * int option * int option * string option * UIElement list * FunctionT list * Position

--- a/Mango/Mango/AbSyn.fs
+++ b/Mango/Mango/AbSyn.fs
@@ -11,8 +11,7 @@ let fromCString (s : string) : string =
         | c           :: l' -> c    :: unescape l'
     Seq.toList s |> unescape |> System.String.Concat
 
-(* position: (line, column) *)
-type Position = int * int  // row, column
+type Position = int * int // (line, column)
 
 type Value =
     | Int of int

--- a/Mango/Mango/AbSyn.fs
+++ b/Mango/Mango/AbSyn.fs
@@ -13,6 +13,8 @@ let fromCString (s : string) : string =
 
 type Position = int * int // (line, column)
 
+type CommonProp = | IsVisible of bool * Position
+
 type Value =
     | Int of int
     | Real of float
@@ -32,9 +34,12 @@ type FunctionT =
     | Function of string * Stmt list * Position
 
 type ButtonProp =
-    | IsVisible of bool * Position
     | Width of int * Position
     | Height of int * Position
+
+type ButtonProperty = 
+    | CommonProp of CommonProp
+    | ButtonProp of ButtonProp
 
 type FontStyleT = 
     | Italic
@@ -101,7 +106,7 @@ type ContainerProp =
     | Margin of Thickness * Position
 
 type UIElement = 
-    | Button of string * ButtonProp list * Position
+    | Button of string * ButtonProperty list * Position
     | TextBlock of string * TextBlockProp list option * Position
     | TextBox of string * Position 
     | CheckBox of string * Position

--- a/Mango/Mango/AvaloniaHelpers/AvaloniaButtonHelpers.fs
+++ b/Mango/Mango/AvaloniaHelpers/AvaloniaButtonHelpers.fs
@@ -4,29 +4,7 @@ open Avalonia.FuncUI.DSL
 open Avalonia.FuncUI.Types
 open Avalonia.Controls
 open AbSyn
-open ViewHelpers
 open AvaloniaCommonHelpers
 
-let applyIsVisible props applied =
-    applyProp props applied (function
-        | CommonProp (IsVisible (b, _)) -> Some (Button.isVisible b)
-        | _ -> None)
-
-let applyWidth props applied =
-    applyProp props applied (function
-        | ButtonProp (Width (num, _)) -> Some (Button.width num)
-        | _ -> None)
-
-let applyHeight props applied =
-    applyProp props applied (function
-        | ButtonProp (Height (num, _)) -> Some (Button.height num)
-        | _ -> None)
-
-let applyButtonProperties props =
-    []
-    |> applyIsVisible props
-    |> applyWidth props
-    |> applyHeight props
-
-let createButton (label: string) (props: ButtonProperty list) : IView =
-    Button.create ([ Button.content label ] @ [AvaloniaCommonHelpers.applyIsVisible<Button> true []] @ applyButtonProperties props)
+let createButton (label: string) (props: CommonProp list) : IView =
+    Button.create ([ Button.content label ] @ applyCommonProps props)

--- a/Mango/Mango/AvaloniaHelpers/AvaloniaButtonHelpers.fs
+++ b/Mango/Mango/AvaloniaHelpers/AvaloniaButtonHelpers.fs
@@ -5,19 +5,21 @@ open Avalonia.FuncUI.Types
 open Avalonia.Controls
 open AbSyn
 open ViewHelpers
+open AvaloniaCommonHelpers
+
 let applyIsVisible props applied =
     applyProp props applied (function
-        | IsVisible (b, _) -> Some (Button.isVisible b)
+        | CommonProp (IsVisible (b, _)) -> Some (Button.isVisible b)
         | _ -> None)
 
 let applyWidth props applied =
     applyProp props applied (function
-        | Width (num, _) -> Some (Button.width num)
+        | ButtonProp (Width (num, _)) -> Some (Button.width num)
         | _ -> None)
 
 let applyHeight props applied =
     applyProp props applied (function
-        | Height (num, _) -> Some (Button.height num)
+        | ButtonProp (Height (num, _)) -> Some (Button.height num)
         | _ -> None)
 
 let applyButtonProperties props =
@@ -26,5 +28,5 @@ let applyButtonProperties props =
     |> applyWidth props
     |> applyHeight props
 
-let createButton (label: string) (props: ButtonProp list) : IView =
-    Button.create ([ Button.content label ] @ applyButtonProperties props)
+let createButton (label: string) (props: ButtonProperty list) : IView =
+    Button.create ([ Button.content label ] @ [AvaloniaCommonHelpers.applyIsVisible<Button> true []] @ applyButtonProperties props)

--- a/Mango/Mango/AvaloniaHelpers/AvaloniaCommonHelpers.fs
+++ b/Mango/Mango/AvaloniaHelpers/AvaloniaCommonHelpers.fs
@@ -1,14 +1,10 @@
 ﻿module AvaloniaCommonHelpers
 
-open Avalonia.FuncUI.DSL
 open Avalonia.FuncUI.Types
 open Avalonia.Controls
 open Avalonia.FuncUI.Builder
+open Avalonia
 open AbSyn
-
-open Avalonia.FuncUI.Types
-open Avalonia.Controls
-open Avalonia.FuncUI.Builder
 
 let applyProp props applied tryExtract =
     props
@@ -16,13 +12,35 @@ let applyProp props applied tryExtract =
     |> Option.map (fun attr -> applied @ [attr])
     |> Option.defaultValue applied
 
-let applyIsVisible<'t when 't :> Control> (value: bool) (acc: IAttr<'t> list) : IAttr<'t> =
-    AttrBuilder<'t>.CreateProperty(Avalonia.Controls.Control.IsVisibleProperty, value, ValueNone)
-
-let applyIsVisibleTest<'a when 'a :> Control> (props: CommonProp list) (applied: IAttr<'a> list) : IAttr<'a> list =
+let applyMargin<'a when 'a :> Control> (props: CommonProp list) (applied: IAttr<'a> list) : IAttr<'a> list =
     applyProp props applied (function
-        | IsVisible (b, _) -> Some (AttrBuilder<'a>.CreateProperty(Avalonia.Controls.Control.IsVisibleProperty, b, ValueNone)))
+        | Margin (m, _) ->
+            let thickness =
+                match m with
+                | Uniform x -> Thickness(float x)
+                | Symmetric (x, y) -> Thickness(float x, float y, float x, float y)
+                | Custom (l, t, r, b) -> Thickness(float l, float t, float r, float b)
+            Some (AttrBuilder<'a>.CreateProperty(Avalonia.Controls.Control.MarginProperty, thickness, ValueNone))
+        | _ -> None)
+
+let applyWidth<'a when 'a :> Control> (props: CommonProp list) (applied: IAttr<'a> list) : IAttr<'a> list =
+    applyProp props applied (function
+        | Width (num, _) -> Some (AttrBuilder<'a>.CreateProperty(Avalonia.Controls.Control.WidthProperty, float num, ValueNone))
+        | _ -> None)
+
+let applyHeight<'a when 'a :> Control> (props: CommonProp list) (applied: IAttr<'a> list) : IAttr<'a> list =
+    applyProp props applied (function
+        | Height (num, _) -> Some (AttrBuilder<'a>.CreateProperty(Avalonia.Controls.Control.HeightProperty, float num, ValueNone))
+        | _ -> None)
+
+let applyIsVisible<'a when 'a :> Control> (props: CommonProp list) (applied: IAttr<'a> list) : IAttr<'a> list =
+    applyProp props applied (function
+        | IsVisible (b, _) -> Some (AttrBuilder<'a>.CreateProperty(Avalonia.Controls.Control.IsVisibleProperty, b, ValueNone))
+        | _ -> None)
 
 let applyCommonProps props = 
     []
     |> applyIsVisible props
+    |> applyWidth props
+    |> applyHeight props
+    |> applyMargin props

--- a/Mango/Mango/AvaloniaHelpers/AvaloniaCommonHelpers.fs
+++ b/Mango/Mango/AvaloniaHelpers/AvaloniaCommonHelpers.fs
@@ -1,0 +1,28 @@
+﻿module AvaloniaCommonHelpers
+
+open Avalonia.FuncUI.DSL
+open Avalonia.FuncUI.Types
+open Avalonia.Controls
+open Avalonia.FuncUI.Builder
+open AbSyn
+
+open Avalonia.FuncUI.Types
+open Avalonia.Controls
+open Avalonia.FuncUI.Builder
+
+let applyProp props applied tryExtract =
+    props
+    |> List.tryPick tryExtract
+    |> Option.map (fun attr -> applied @ [attr])
+    |> Option.defaultValue applied
+
+let applyIsVisible<'t when 't :> Control> (value: bool) (acc: IAttr<'t> list) : IAttr<'t> =
+    AttrBuilder<'t>.CreateProperty(Avalonia.Controls.Control.IsVisibleProperty, value, ValueNone)
+
+let applyIsVisibleTest<'a when 'a :> Control> (props: CommonProp list) (applied: IAttr<'a> list) : IAttr<'a> list =
+    applyProp props applied (function
+        | IsVisible (b, _) -> Some (AttrBuilder<'a>.CreateProperty(Avalonia.Controls.Control.IsVisibleProperty, b, ValueNone)))
+
+let applyCommonProps props = 
+    []
+    |> applyIsVisible props

--- a/Mango/Mango/AvaloniaHelpers/AvaloniaCommonPropsHelpers.fs
+++ b/Mango/Mango/AvaloniaHelpers/AvaloniaCommonPropsHelpers.fs
@@ -1,0 +1,14 @@
+﻿module AvaloniaCommonPropsHelpers
+
+open Avalonia.FuncUI.Types
+
+let applyIsVisible props applied =
+    applyProp props applied (function
+        | IsVisible (b, _) -> Some (Button.isVisible b)
+        | _ -> None)
+
+let applyCommonProps props (ctrl: IView list) =
+    ctrl
+    |> applyIsVisible props
+    |> applyWidth props
+    |> applyHeight props

--- a/Mango/Mango/AvaloniaHelpers/AvaloniaContainerHelpers.fs
+++ b/Mango/Mango/AvaloniaHelpers/AvaloniaContainerHelpers.fs
@@ -6,6 +6,8 @@ open AbSyn
 open Avalonia.Layout
 open Avalonia
 open ViewHelpers
+open AvaloniaCommonHelpers
+
 let applyOrientation props applied =
     applyProp props applied (function
         | Layout (layout, _) ->
@@ -14,18 +16,10 @@ let applyOrientation props applied =
             | Vertical -> Some (StackPanel.orientation Orientation.Vertical)
         | _ -> None)
 
-let applyMargin props applied =
-    applyProp props applied (function
-        | Margin (m, _) ->
-            let thickness =
-                match m with
-                | Uniform x -> Thickness(float x)
-                | Symmetric (x, y) -> Thickness(float x, float y, float x, float y)
-                | Custom (l, t, r, b) -> Thickness(float l, float t, float r, float b)
-            Some (StackPanel.margin thickness)
-        | _ -> None)
-
-let applyContainerProperties props =
+let applyContainerProperties (props : ContainerProp list) =
     []
     |> applyOrientation props
-    |> applyMargin props
+
+let applyContainerCommonProperties (props : CommonProp list) =
+    []
+    |> applyMargin<StackPanel> props

--- a/Mango/Mango/AvaloniaHelpers/AvaloniaHelpers.fs
+++ b/Mango/Mango/AvaloniaHelpers/AvaloniaHelpers.fs
@@ -61,20 +61,26 @@ let createToggleButton = ToggleButton.create []
 
 let rec convertUIElementToIView element =
     match element with
-    | Button (label,props, _) -> createButton label props
-    | TextBlock (label, Some props, _) -> createTextBlock label props
-    | TextBlock (label, None, _) -> createTextBlock label []
+    | Button (label, Some props, _) -> createButton label props
+    | Button (label, None, _) -> createButton label []
+    | TextBlock (label, Some commonProps, Some props, _) -> createTextBlock label commonProps props
+    | TextBlock (label, Some commonProps, None, _) -> createTextBlock label commonProps []
+    | TextBlock (label, None, Some props, _) -> createTextBlock label [] props
+    | TextBlock (label, None, None, _) -> createTextBlock label [] []
     | TextBox (label, _) -> createTextBox label
     | CheckBox (label, _) -> createCheckbox label
     | RadioButton (label, _) -> createRadioButton label
     | ToggleSwitch (label, _) -> createToggleSwitch label
     | Calendar _ -> createCalendar
     | ToggleButton _ -> createToggleButton
-    | Container (props,elements,_) -> createContainer (props, elements)
+    | Container (Some commonProps, Some containerProps, elements, _) -> createContainer commonProps containerProps elements
+    | Container (Some commonProps, None, elements, _) -> createContainer commonProps [] elements
+    | Container (None, Some containerProps, elements, _) -> createContainer [] containerProps elements
+    | Container (None, None, elements, _) -> createContainer [] [] elements
 
-and createContainer (props: ContainerProp list, elements: UIElement list): IView =
+and createContainer (commonProps: CommonProp list) (props: ContainerProp list) (elements: UIElement list): IView =
     StackPanel.create (
-      [ StackPanel.children (List.map convertUIElementToIView elements) ] @ applyContainerProperties props
+      [ StackPanel.children (List.map convertUIElementToIView elements) ] @ applyContainerCommonProperties commonProps @ applyContainerProperties props
     )
 
 let setWindowContent elements (window: HostWindow) =

--- a/Mango/Mango/AvaloniaHelpers/AvaloniaTextBlockHelpers.fs
+++ b/Mango/Mango/AvaloniaHelpers/AvaloniaTextBlockHelpers.fs
@@ -34,6 +34,6 @@ let applyTextBlockProperties props =
     |> applyFontFamily props
     |> applyFontSize props
 
-let createTextBlock (text: string) (props: TextBlockProp list) : IView =
+let createTextBlock (text: string) (commonProps: CommonProp list) (props: TextBlockProp list) : IView =
     TextBlock.create ([ TextBlock.text text ] @ applyTextBlockProperties props)
 

--- a/Mango/Mango/FileIO.fs
+++ b/Mango/Mango/FileIO.fs
@@ -1,0 +1,8 @@
+﻿module FileIO
+
+open System.IO
+
+let readContent path =
+    try
+        File.ReadAllText(path) |> Ok
+    with ex -> Error $"Could not read file: {ex.Message}"

--- a/Mango/Mango/Lexer.fsl
+++ b/Mango/Mango/Lexer.fsl
@@ -18,7 +18,10 @@ let rec getLineCol pos line = function
 let getPos (lexbuf: LexBuffer<'char>) =
     getLineCol lexbuf.StartPos.pos_cnum currentLine lineStartPos
 
-exception LexicalError of string * (int * int) // (message, (line, column))
+type Position = int * int // (line, column)
+(* Custom exception for lexer errors *)
+
+exception LexicalError of string * Position
 
 let lexerError lexbuf s =
     raise (LexicalError (s, getPos lexbuf))
@@ -150,4 +153,4 @@ rule Token = parse
   | '='                     { Parser.EQUAL (getPos lexbuf) }
   | eof                     { Parser.EOF (getPos lexbuf) }
 
-  | _                       { lexerError lexbuf "Illegal symbol in input" }
+  | _ { raise (LexicalError($"Unexpected character", (lexbuf.StartPos.Line, lexbuf.StartPos.Column))) }

--- a/Mango/Mango/Mango.fs
+++ b/Mango/Mango/Mango.fs
@@ -1,106 +1,67 @@
-﻿module Program
+﻿module Globals =
+    let filepath = ref None
 
-open Avalonia
-open Avalonia.Controls.ApplicationLifetimes
-open Avalonia.Themes.Fluent
-open Avalonia.FuncUI.Hosts
-open System.IO
-open FSharp.Text.Lexing
-open System.Text
-open Interpreter
+module FileIO =
 
-let mutable filepath = ""
+    open System.IO
 
-exception SyntaxError of int * int
+    let readContent path =
+        try
+            File.ReadAllText(path) |> Ok
+        with ex -> Error $"Could not read file: {ex.Message}"
 
-let printPos (errString : string) : unit =
-    let rec state3 (s : string) (p : int) (lin : string) (col : int) =
-        (* read digits until not *)
-        let c = s.[p]
-        if System.Char.IsDigit c
-        then state3 s (p-1) (System.Char.ToString c + lin) col
-        else raise (SyntaxError (System.Int32.Parse lin, col))
+module ParserWrapper =
 
-    let rec state2 (s : string) (p : int) (col : string) =
-        (* skip from position until digit *)
-        let c = s.[p]
-        if System.Char.IsDigit c
-        then state3 s (p-1) (System.Char.ToString c) (System.Int32.Parse col)
-        else state2 s (p-1) col
+    open System.Text
+    open FSharp.Text.Lexing
 
-    let rec state1 (s : string) (p : int) (col : string) =
-        (* read digits until not *)
-        let c = s.[p]
-        if System.Char.IsDigit c
-        then state1 s (p-1) (System.Char.ToString c + col)
-        else state2 s (p-1) col
+    let parseString (source: string) =
+        try
+            let lexbuf = LexBuffer<_>.FromBytes(Encoding.UTF8.GetBytes(source))
+            Ok (Parser.Prog Lexer.Token lexbuf)
+        with
+        | Lexer.LexicalError (msg, (line, col)) ->
+            Error $"Lexical error: {msg} at line {line}, column {col}"
+        | ex -> Error $"Parser error: {ex.Message}"
 
-    let rec state0 (s : string) (p : int) =
-        (* skip from end until digit *)
-        let c = s.[p]
-        if System.Char.IsDigit c
-        then state1 s (p-1) (System.Char.ToString c)
-        else state0 s (p-1)
+module AppMain =
 
-    state0 errString (String.length errString - 1)
+    open Avalonia
+    open Avalonia.Controls.ApplicationLifetimes
+    open Avalonia.FuncUI.Hosts
+    open Avalonia.Themes.Fluent
+    open FileIO
+    open ParserWrapper
+    open Interpreter
 
-/// <summary> Lexes and parses a mango file</summary>
-/// <param name="s">string representing mango file</param>
-/// <returns>Abstract Syntax tree or error message</returns>
-let parseString (s : string) =
-    try 
-        Ok (Parser.Prog Lexer.Token <| LexBuffer<_>.FromBytes (Encoding.UTF8.GetBytes s))
-    with 
-        | Lexer.LexicalError (info,(line,col)) ->
-            Error (sprintf "%s at line %d, position %d\n" info line col)
-        | ex -> Error ex.Message
+    let mutable filepath = "examples/window.mango"
 
-/// <summary>Read the file at the path given as parameter and return the result</summary>
-/// <param name="path">Path to mango program</param>
-/// <returns>Result containing string of the read file or IO error</returns>
-let readContent path = 
-    try // read text from file given as parameter with added extension
-        let inStream = File.OpenText path
-        let txt = inStream.ReadToEnd()
-        inStream.Close()
-        Ok txt
-    with // or return the exception
-        | ex -> Error ex
+    type App() =
+        inherit Application()
+        override this.Initialize() =
+            this.Styles.Add(FluentTheme())
 
-/// <summary>Open file and perform lexing and parsing on the mango file</summary>
-/// <param name="filename">Path to mango file</param>
-/// <returns> The abstract syntax tree or an error message</returns>
-let parseMangoFile (filename : string) =
-  let txt = readContent filename
-  match txt with
-  | Ok content -> parseString content
-  | Error error -> Error error.Message
-
-type App() =
-    inherit Application()
-
-    override this.Initialize() =
-        this.Styles.Add (FluentTheme())
-
-    override this.OnFrameworkInitializationCompleted() =
-        let absyn = parseMangoFile filepath
-
-        match absyn with
-        | Ok syntax_tree ->
-            match this.ApplicationLifetime with
-            | :? IClassicDesktopStyleApplicationLifetime as desktopLifetime ->
-                desktopLifetime.MainWindow <- interpret (new HostWindow()) syntax_tree
-            | _ -> ()
-        | Error message -> failwith message
+        override this.OnFrameworkInitializationCompleted() =
+            match readContent filepath with
+            | Error err -> failwithf "File error: %s" err
+            | Ok source ->
+                match parseString source with
+                | Error msg -> failwithf "Parse error: %s" msg
+                | Ok syntax_tree ->
+                    match this.ApplicationLifetime with
+                    | :? IClassicDesktopStyleApplicationLifetime as desktop ->
+                        desktop.MainWindow <- interpret (HostWindow()) syntax_tree
+                    | _ -> ()
 
 module Program =
 
+    open Avalonia
+    open AppMain
+
     [<EntryPoint>]
-    let main(args: string[]) =
-        if args.Length = 0 then
-            do filepath <- "examples/window.mango"
-        else
-            do filepath <- args[0]
+    let main (args: string[]) =
+        let path = if args.Length > 0 then args[0] else "examples/test.mango"
+        Globals.filepath.Value <- Some path
         AppBuilder
             .Configure<App>()
             .UsePlatformDetect()

--- a/Mango/Mango/Mango.fs
+++ b/Mango/Mango/Mango.fs
@@ -1,29 +1,6 @@
 ﻿module Globals =
     let filepath = ref None
 
-module FileIO =
-
-    open System.IO
-
-    let readContent path =
-        try
-            File.ReadAllText(path) |> Ok
-        with ex -> Error $"Could not read file: {ex.Message}"
-
-module ParserWrapper =
-
-    open System.Text
-    open FSharp.Text.Lexing
-
-    let parseString (source: string) =
-        try
-            let lexbuf = LexBuffer<_>.FromBytes(Encoding.UTF8.GetBytes(source))
-            Ok (Parser.Prog Lexer.Token lexbuf)
-        with
-        | Lexer.LexicalError (msg, (line, col)) ->
-            Error $"Lexical error: {msg} at line {line}, column {col}"
-        | ex -> Error $"Parser error: {ex.Message}"
-
 module AppMain =
 
     open Avalonia
@@ -34,15 +11,13 @@ module AppMain =
     open ParserWrapper
     open Interpreter
 
-    let mutable filepath = "examples/window.mango"
-
     type App() =
         inherit Application()
         override this.Initialize() =
             this.Styles.Add(FluentTheme())
 
         override this.OnFrameworkInitializationCompleted() =
-            match readContent filepath with
+            match readContent Globals.filepath.Value.Value with
             | Error err -> failwithf "File error: %s" err
             | Ok source ->
                 match parseString source with
@@ -60,7 +35,7 @@ module Program =
 
     [<EntryPoint>]
     let main (args: string[]) =
-        let path = if args.Length > 0 then args[0] else "examples/test.mango"
+        let path = if args.Length > 0 then args[0] else "examples/window.mango"
         Globals.filepath.Value <- Some path
         AppBuilder
             .Configure<App>()

--- a/Mango/Mango/Mango.fsproj
+++ b/Mango/Mango/Mango.fsproj
@@ -24,6 +24,7 @@
 		<Compile Include="AbSyn.fs" />
 		<Compile Include="Parser.fs" />
     	<Compile Include="Lexer.fs" />
+    	<Compile Include="AvaloniaHelpers\AvaloniaCommonHelpers.fs" />
 		<Compile Include="AvaloniaHelpers/ColorConverter.fs" />
 		<Compile Include="AvaloniaHelpers/ViewHelpers.fs" />
 		<Compile Include="AvaloniaHelpers/AvaloniaButtonHelpers.fs" />

--- a/Mango/Mango/Mango.fsproj
+++ b/Mango/Mango/Mango.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -10,6 +10,8 @@
   	</ItemGroup>
 
 	<ItemGroup>
+		
+		<Compile Include="FileIO.fs" />
 		<Compile Include="SymTab.fsi" />
     	<Compile Include="SymTab.fs" />
     	
@@ -29,7 +31,7 @@
 		<Compile Include="AvaloniaHelpers/AvaloniaContainerHelpers.fs" />
 		<Compile Include="AvaloniaHelpers/AvaloniaHelpers.fs" />
 		<Compile Include="Interpreter.fs" />
-
+		<Compile Include="ParserWrapper.fs" />
 		<Compile Include="Mango.fs" />
 	</ItemGroup>
 

--- a/Mango/Mango/Parser.fsy
+++ b/Mango/Mango/Parser.fsy
@@ -23,7 +23,7 @@ let add_ui_elements window elements =
   match window with
   | Window (name, width, height, icon, _, functions, pos) -> Window (name, width, height, icon, elements, functions, pos)
 
-let default_button_props pos = [IsVisible (true, pos)]
+let default_button_props pos = [CommonProp (IsVisible (true, pos))]
 let default_text_props pos = []
 
 let parse_hex_code (s: string) : (byte * byte * byte * byte) option =
@@ -65,8 +65,8 @@ let parse_hex_code (s: string) : (byte * byte * byte * byte) option =
 // Types
 %type <AbSyn.UIElement list> UIElements
 %type <AbSyn.UIElement> UIElement
-%type <AbSyn.ButtonProp list> ButtonProps
-%type <AbSyn.ButtonProp> ButtonProp
+%type <AbSyn.ButtonProperty list> ButtonProps
+%type <AbSyn.ButtonProperty> ButtonProp
 %type <AbSyn.TextBlockProp list> TextProps
 %type <AbSyn.TextBlockProp> TextProp
 %type <AbSyn.ColorT> Color
@@ -99,7 +99,7 @@ ContainerProps :
 
 UIElement :
     BUTTON STRINGLIT                                                              { Button (fst $2, default_button_props $1, $1) }
-  | BUTTON STRINGLIT LEFT_CURLY_BRACKET ButtonProps RIGHT_CURLY_BRACKET           { Button (fst $2, $4, $1) }
+  | BUTTON STRINGLIT LEFT_CURLY_BRACKET ButtonProperties RIGHT_CURLY_BRACKET           { Button (fst $2, $4, $1) }
   | TEXT STRINGLIT                                                                { TextBlock (fst $2, None, $1) }
   | TEXT STRINGLIT LEFT_CURLY_BRACKET TextProps RIGHT_CURLY_BRACKET               { TextBlock (fst $2, Some $4, $1) }
   | TEXTBOX STRINGLIT                                                             { TextBox (fst $2, $1) }
@@ -121,15 +121,28 @@ Funcs : Function Funcs { $1 :: $2 }
       | Function       { [$1] }
 ;
 
+ButtonProperties : ButtonProp ButtonProperties { $1 :: $2 }
+  | CommonProp ButtonProperties { $1 :: $2 }
+  | ButtonProp            { [$1] }
+  | CommonProp            { [$1] }
+;
+
 // Button Props
 ButtonProps : ButtonProp ButtonProps { $1 :: $2 }
   | ButtonProp            { [$1] }
 ;
 
-ButtonProp : IS_VISIBLE COLON TRUE  { IsVisible (true, $1) }
-  | IS_VISIBLE COLON FALSE { IsVisible (false, $1) }
-  | WIDTH COLON NUM        { Width (fst $3, $1) }
-  | HEIGHT COLON NUM       { Height (fst $3, $1) }
+ButtonProp :
+  | WIDTH COLON NUM        { ButtonProp (Width (fst $3, $1)) }
+  | HEIGHT COLON NUM       { ButtonProp (Height (fst $3, $1)) }
+;
+
+CommonProps : CommonProp CommonProps { $1 :: $2 }
+  | CommonProp            { [$1] }
+;
+
+CommonProp : IS_VISIBLE COLON TRUE { CommonProp (IsVisible (true, $1)) }
+  | IS_VISIBLE COLON FALSE { CommonProp (IsVisible (false, $1)) }
 ;
 
 // Text Props

--- a/Mango/Mango/Parser.fsy
+++ b/Mango/Mango/Parser.fsy
@@ -7,12 +7,12 @@ open AbSyn
 (* parse-error function *)
 let mutable ErrorContextDescriptor : string = ""
 
-let parse_error_rich =
-  Some (fun (ctxt: ParseErrorContext<_>) ->
+let parse_error_rich : (ParseErrorContext<'tok> -> unit) option =
+  Some (fun ctxt ->
     ErrorContextDescriptor <-
-      match ctxt.CurrentToken with
-      | None -> "At beginning of input\n"
-      | Some token -> sprintf "at token %A\n" token
+        match ctxt.CurrentToken with
+        | Some tok -> $"Syntax error at token {tok}. {ctxt.Message}"
+        | None -> "Syntax error at beginning of file"
   )
 
 let construct_window window elements functions = 

--- a/Mango/Mango/Parser.fsy
+++ b/Mango/Mango/Parser.fsy
@@ -23,9 +23,6 @@ let add_ui_elements window elements =
   match window with
   | Window (name, width, height, icon, _, functions, pos) -> Window (name, width, height, icon, elements, functions, pos)
 
-let default_button_props pos = [CommonProp (IsVisible (true, pos))]
-let default_text_props pos = []
-
 let parse_hex_code (s: string) : (byte * byte * byte * byte) option =
   let hex = if s.StartsWith("#") then s.Substring(1) else s
   let tryByte i = System.Byte.TryParse(hex.Substring(i,2), System.Globalization.NumberStyles.HexNumber, null)
@@ -37,6 +34,13 @@ let parse_hex_code (s: string) : (byte * byte * byte * byte) option =
       let (rOk, r), (gOk, g), (bOk, b), (aOk, a) = tryByte 0, tryByte 2, tryByte 4, tryByte 6
       if rOk && gOk && bOk && aOk then Some (r, g, b, a) else None
   | _ -> None
+
+let splitInterleaved props =
+    List.foldBack (fun prop (cs, ss) ->
+        match prop with
+        | Common c   -> (c :: cs, ss)
+        | Specific s -> (cs, s :: ss)
+    ) props ([], [])
 %}
 
 // Tokens with values
@@ -65,10 +69,10 @@ let parse_hex_code (s: string) : (byte * byte * byte * byte) option =
 // Types
 %type <AbSyn.UIElement list> UIElements
 %type <AbSyn.UIElement> UIElement
-%type <AbSyn.ButtonProperty list> ButtonProps
-%type <AbSyn.ButtonProperty> ButtonProp
-%type <AbSyn.TextBlockProp list> TextProps
+%type <AbSyn.InterleavedProp<TextBlockProp> list> TextProps
 %type <AbSyn.TextBlockProp> TextProp
+%type <AbSyn.InterleavedProp<ContainerProp> list> ContainerProps
+%type <AbSyn.ContainerProp> ContainerProp
 %type <AbSyn.ColorT> Color
 %type <AbSyn.FunctionT> Function
 %type <AbSyn.Stmt list> Statements
@@ -91,24 +95,37 @@ Window : WINDOW STRINGLIT { Window (fst $2, None, None, None, [], [], $1) }
 
 ContainerProp : 
     LAYOUT COLON Layout { Layout ($3, $1) }
-  | MARGIN COLON ContainerMargin { ContainerProp.Margin ($3, $1) }
+
+InterleavedContainerProp :
+    ContainerProp     { Specific $1 }
+  | CommonProp        { Common $1 }
+;
 
 ContainerProps :
-    ContainerProp ContainerProps  { $1 :: $2 }
-  | ContainerProp             { [$1] }
+    InterleavedContainerProp ContainerProps { $1 :: $2 }
+  | InterleavedContainerProp                { [$1] }
+;
 
 UIElement :
-    BUTTON STRINGLIT                                                              { Button (fst $2, default_button_props $1, $1) }
-  | BUTTON STRINGLIT LEFT_CURLY_BRACKET ButtonProperties RIGHT_CURLY_BRACKET           { Button (fst $2, $4, $1) }
-  | TEXT STRINGLIT                                                                { TextBlock (fst $2, None, $1) }
-  | TEXT STRINGLIT LEFT_CURLY_BRACKET TextProps RIGHT_CURLY_BRACKET               { TextBlock (fst $2, Some $4, $1) }
-  | TEXTBOX STRINGLIT                                                             { TextBox (fst $2, $1) }
-  | CHECKBOX STRINGLIT                                                            { CheckBox (fst $2, $1) }
-  | RADIOBUTTON STRINGLIT                                                         { RadioButton (fst $2, $1) }
-  | TOGGLESWITCH STRINGLIT                                                        { ToggleSwitch (fst $2, $1) }
-  | CALENDAR                                                                      { Calendar $1 }
-  | TOGGLEBUTTON                                                                  { ToggleButton $1 }
-  | CONTAINER LEFT_CURLY_BRACKET ContainerProps UIElements RIGHT_CURLY_BRACKET    { Container ($3, $4, $1)}
+    BUTTON STRINGLIT                                                                { Button (fst $2, None, $1) }
+  | BUTTON STRINGLIT LEFT_CURLY_BRACKET ButtonProperties RIGHT_CURLY_BRACKET        { Button (fst $2, Some $4, $1) }
+  | TEXT STRINGLIT                                                                  { TextBlock (fst $2, None, None, $1) }
+  | TEXT STRINGLIT LEFT_CURLY_BRACKET TextProps RIGHT_CURLY_BRACKET
+    {
+        let commonProps, specificProps = splitInterleaved $4
+        TextBlock(fst $2, Some commonProps, Some specificProps, $1)
+    }
+  | TEXTBOX STRINGLIT                                                               { TextBox (fst $2, $1) }
+  | CHECKBOX STRINGLIT                                                              { CheckBox (fst $2, $1) }
+  | RADIOBUTTON STRINGLIT                                                           { RadioButton (fst $2, $1) }
+  | TOGGLESWITCH STRINGLIT                                                          { ToggleSwitch (fst $2, $1) }
+  | CALENDAR                                                                        { Calendar $1 }
+  | TOGGLEBUTTON                                                                    { ToggleButton $1 }
+  | CONTAINER LEFT_CURLY_BRACKET ContainerProps UIElements RIGHT_CURLY_BRACKET 
+    { 
+        let commonProps, specificProps = splitInterleaved $3
+        Container (Some commonProps, Some specificProps, $4, $1)
+    }
 ;
 
 UIElements :
@@ -121,33 +138,25 @@ Funcs : Function Funcs { $1 :: $2 }
       | Function       { [$1] }
 ;
 
-ButtonProperties : ButtonProp ButtonProperties { $1 :: $2 }
-  | CommonProp ButtonProperties { $1 :: $2 }
-  | ButtonProp            { [$1] }
+ButtonProperties : CommonProp ButtonProperties { $1 :: $2 }
   | CommonProp            { [$1] }
 ;
 
-// Button Props
-ButtonProps : ButtonProp ButtonProps { $1 :: $2 }
-  | ButtonProp            { [$1] }
-;
-
-ButtonProp :
-  | WIDTH COLON NUM        { ButtonProp (Width (fst $3, $1)) }
-  | HEIGHT COLON NUM       { ButtonProp (Height (fst $3, $1)) }
+Margin :
+     NUM                               { Uniform (fst $1) }
+  |  NUM COMMA NUM                     { Symmetric (fst $1, fst $3) }
+  |  NUM COMMA NUM COMMA NUM COMMA NUM { Custom (fst $1, fst $3, fst $5, fst $7) }
 ;
 
 CommonProps : CommonProp CommonProps { $1 :: $2 }
   | CommonProp            { [$1] }
 ;
 
-CommonProp : IS_VISIBLE COLON TRUE { CommonProp (IsVisible (true, $1)) }
-  | IS_VISIBLE COLON FALSE { CommonProp (IsVisible (false, $1)) }
-;
-
-// Text Props
-TextProps : TextProp TextProps { $1 :: $2 }
-  | TextProp           { [$1] }
+CommonProp : IS_VISIBLE COLON TRUE { IsVisible (true, $1) }
+  | IS_VISIBLE COLON FALSE { IsVisible (false, $1) }
+  | WIDTH COLON NUM        { Width (fst $3, $1) }
+  | HEIGHT COLON NUM       { Height (fst $3, $1) }
+  | MARGIN COLON Margin    { Margin ($3, $1) }
 ;
 
 TextProp :
@@ -157,11 +166,20 @@ TextProp :
   | FONTSIZE COLON NUM          { FontSize (fst $3, $1) }
   | FONTWEIGHT COLON NUM        { FontWeight (fst $3, $1) }
   | FONTSTYLE COLON FontStyles  { FontStyle (List.rev $3, $1) }
-  | MARGIN COLON TextMargin    { TextBlockProp.Margin ($3, $1) }
   | LINEHEIGHT COLON NUM        { LineHeight (fst $3, $1) }
   | TEXTALIGN COLON TextAlign   { TextAlign ($3, $1) }
   | TEXTWRAP COLON TextWrap     { TextWrap ($3, $1) }
   | TEXTTRIM COLON TextTrim     { TextTrim ($3, $1) }
+;
+
+InterleavedTextProp :
+    TextProp      { Specific $1 }
+  | CommonProp        { Common $1 }
+;
+
+TextProps :
+    InterleavedTextProp TextProps { $1 :: $2 }
+  | InterleavedTextProp           { [$1] }
 ;
 
 // Color
@@ -204,12 +222,6 @@ TextWrap : OVERFLOW   { Overflow }
 TextTrim : WORD      { Word }
   | CHARACTER { Character }
   | NOTRIM    { NoTrim }
-;
-
-ContainerMargin :
-     NUM                               { Uniform (fst $1) }
-  |  NUM COMMA NUM                     { Symmetric (fst $1, fst $3) }
-  |  NUM COMMA NUM COMMA NUM COMMA NUM { Custom (fst $1, fst $3, fst $5, fst $7) }
 ;
 
 TextMargin :

--- a/Mango/Mango/ParserWrapper.fs
+++ b/Mango/Mango/ParserWrapper.fs
@@ -1,0 +1,13 @@
+﻿module ParserWrapper
+
+open System.Text
+open FSharp.Text.Lexing
+
+let parseString (source: string) =
+    try
+        let lexbuf = LexBuffer<_>.FromBytes(Encoding.UTF8.GetBytes source)
+        Ok (Parser.Prog Lexer.Token lexbuf)
+    with
+    | Lexer.LexicalError (msg, (line, col)) -> 
+           Error $"Lexical error: {msg} at line {line}, column {col}"
+    | ex -> Error $"Parser error: {ex.Message}"


### PR DESCRIPTION
This PR performs refactoring on the Mango codebase. The following changes have been done:

- Refactoring and separate logic from Mango.fs into multiple modules
- Create a algebraic datatype that represents properties that are common among many controls
- Extract helper functions from Button and Container to subtype generic helper functions for applying properties
- Adjust and many it possible to interleave between Component specific props and common props
- Begin slowly introducing better error handling in Mango DSL.